### PR TITLE
Update to the link hrefs to account for the regeneration of the file

### DIFF
--- a/main.js
+++ b/main.js
@@ -236,7 +236,7 @@ async function transformArchiData(data) {
                 description: capability.$.documentation || '',
                 input: extractProperties(capability.properties, 'Input'),
                 output: extractProperties(capability.properties, 'Output'),
-                href: page && page._links ? page._links.webui : null,
+                href: page && page._links ? convertToDisplayUrl(page._links.webui) : null,
             };
         })
     );
@@ -469,6 +469,7 @@ async function getPageByTitle(title) {
 async function createOrUpdatePage(title, parentId, content) {
     const pageTitle = `${PAGE_PREFIX}${title}`;
     const existingPage = await getPageByTitle(pageTitle);
+
     const url = existingPage
         ? `${CONFLUENCE_BASE_URL}/rest/api/content/${existingPage.id}?notifyWatchers=false`
         : `${CONFLUENCE_BASE_URL}/rest/api/content`;
@@ -501,6 +502,16 @@ async function createOrUpdatePage(title, parentId, content) {
         console.log(error);
         console.error(`Error ${existingPage ? 'updating' : 'creating'} page "${pageTitle}":`, error.message);
     }
+}
+
+function convertToDisplayUrl(webui) {
+  const match = webui.match(/^\/spaces\/([^/]+)\/pages\/\d+\/(.+)$/);
+  if (!match) return null;
+
+  const spaceKey = match[1];
+  const pageTitle = match[2];
+
+  return `/display/${spaceKey}/${pageTitle}`;
 }
 
 async function uploadAttachment(title,filePath) {

--- a/templates/productTemplate.md
+++ b/templates/productTemplate.md
@@ -19,7 +19,7 @@ ${description}
 
 <h2>Product Container Diagram</h2>
 <ac:image ac:align="center">
-  <ri:url ri:value="https://nhsdigital.github.io/dtos-solution-architecture/c4/${containerDiagram}" />
+  <ri:url ri:value="https://nhsdigital.github.io/dtos-solution-architecture/eventcatalog/c4/${containerDiagram}" />
 </ac:image>
 
 <h2>Product Data Domain</h2>

--- a/templates/productTopLevelTemplate.md
+++ b/templates/productTopLevelTemplate.md
@@ -23,7 +23,7 @@ The diagram below illustrates the overarching System Context View of all the Pro
 <br/>
 
 <ac:image ac:align="center">
-  <ri:url ri:value="https://nhsdigital.github.io/dtos-solution-architecture/c4/dtosSystemContext.png" />
+  <ri:url ri:value="https://nhsdigital.github.io/dtos-solution-architecture/eventcatalog/c4/dtosSystemContext.png" />
 </ac:image>
 
 <br/>
@@ -33,7 +33,7 @@ The overarching system context is large and does look complex, therefore for the
 <h2>Cohort Manager</h2>
 
 <ac:image ac:align="center">
-  <ri:url ri:value="https://nhsdigital.github.io/dtos-solution-architecture/c4/cohortManagerSystemContext.png" />
+  <ri:url ri:value="https://nhsdigital.github.io/dtos-solution-architecture/eventcatalog/c4/cohortManagerSystemContext.png" />
 </ac:image>
 
 <h2>Products</h2>


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Now that the pages get regenerated each time, it means the ID value changes and so therefore the links can no longer reference the pageid, otherwise we end up with broken links. So now it references the page title name

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
